### PR TITLE
Add D1-backed rate limiting for Slack endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# dtlogs-worker
+
+Cloudflare Worker for Slack interactions.
+
+## Rate limiting
+
+All `/slack/*` endpoints are protected by a D1-backed rate limiter.
+It tracks request attempts per user in the `request_log` table and
+returns **429 Too Many Requests** when the number of attempts exceeds
+the allowed threshold in the configured window.
+
+Environment variables:
+
+- `RATE_LIMIT_MAX` (default `5`) – maximum requests allowed per user
+  within the window.
+- `RATE_LIMIT_WINDOW` (default `60`) – window size in seconds.
+
+## Deployment
+
+Apply `schema.sql` to the D1 database and deploy with Wrangler:
+
+```bash
+wrangler d1 execute <DB_NAME> --file=schema.sql
+wrangler deploy
+```

--- a/schema.sql
+++ b/schema.sql
@@ -9,3 +9,11 @@ CREATE TABLE IF NOT EXISTS question_history(
 );
 CREATE UNIQUE INDEX IF NOT EXISTS uq_user_cat_q
 ON question_history(user_id, category, question);
+
+CREATE TABLE IF NOT EXISTS request_log(
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id TEXT NOT NULL,
+  requested_at INTEGER NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_request_log_user_time
+ON request_log(user_id, requested_at);

--- a/src/rate-limit.js
+++ b/src/rate-limit.js
@@ -1,0 +1,23 @@
+export async function isRateLimited(db, userId, limit = 5, windowSec = 60) {
+  const now = Math.floor(Date.now() / 1000);
+  const windowStart = now - windowSec;
+
+  // remove stale records
+  await db.prepare('DELETE FROM request_log WHERE requested_at < ?')
+    .bind(windowStart)
+    .run();
+
+  const { results } = await db.prepare(
+    'SELECT COUNT(*) as count FROM request_log WHERE user_id = ? AND requested_at >= ?'
+  )
+    .bind(userId, windowStart)
+    .all();
+  const count = results[0]?.count ?? 0;
+
+  if (count >= limit) return true;
+
+  await db.prepare('INSERT INTO request_log (user_id, requested_at) VALUES (?, ?)')
+    .bind(userId, now)
+    .run();
+  return false;
+}

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,7 +1,37 @@
+import { isRateLimited } from './rate-limit.js';
+
+async function extractUserId(req) {
+  const contentType = req.headers.get('content-type') || '';
+  try {
+    if (contentType.includes('application/json')) {
+      const data = await req.json();
+      return data.userId || data.user_id || null;
+    }
+    if (contentType.includes('application/x-www-form-urlencoded')) {
+      const form = await req.formData();
+      return form.get('user_id');
+    }
+  } catch (e) {
+    return null;
+  }
+  return null;
+}
+
 export default {
-  async fetch(req) {
+  async fetch(req, env) {
     const { pathname } = new URL(req.url);
     if (pathname === '/health') return new Response('ok', { status: 200 });
+
+    if (pathname.startsWith('/slack/')) {
+      const userId = await extractUserId(req.clone());
+      if (userId) {
+        const limit = parseInt(env.RATE_LIMIT_MAX || '5', 10);
+        const windowSec = parseInt(env.RATE_LIMIT_WINDOW || '60', 10);
+        const blocked = await isRateLimited(env.DB, userId, limit, windowSec);
+        if (blocked) return new Response('Too Many Requests', { status: 429 });
+      }
+    }
+
     if (req.method === 'POST' && pathname === '/slack/category')
       return new Response('처리 중…(stub)', { status: 200 });
     return new Response('not found', { status: 404 });

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -7,6 +7,6 @@ account_id = "7febaff00764d1a1d9b4ebb8b095df51"
 crons = ["0 0 * * *"]  # KST 09:00
 
 [[d1_databases]]
-binding = "dtlogs_db"
+binding = "DB"
 database_name = "dtlogs-db"
 database_id = "0614bd30-1c0b-40a2-98de-34efa2b54247"


### PR DESCRIPTION
## Summary
- add `request_log` table for tracking request attempts
- throttle `/slack/*` endpoints with a D1-backed rate limiter
- document rate limit configuration and deployment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ba3ca24014832bad5fb8fb1b9eb365