### PR TITLE
Limit category search to reputable English engineering blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ DAYS_LIMIT=1460
 LANG_THRESHOLD=0.9
 ```
 
+`ALLOWED_SITES` is optional; if omitted a default list of well known
+company engineering blogs (Netflix, Uber, Dropbox, Airbnb, Stripe,
+Google Cloud, AWS, Spotify and Meta) will be used.
+
 ## Deployment
 
 Apply `schema.sql` to the D1 database and deploy with Wrangler:

--- a/src/tavily.js
+++ b/src/tavily.js
@@ -1,12 +1,50 @@
+const DEFAULT_DOMAINS = [
+  'netflixtechblog.com',
+  'eng.uber.com',
+  'dropbox.tech',
+  'medium.com/airbnb-engineering',
+  'stripe.com/blog',
+  'cloud.google.com/blog',
+  'aws.amazon.com/blogs',
+  'engineering.atspotify.com',
+  'engineering.fb.com'
+];
+
+const KEYWORDS = ['deep dive', 'case study', 'architecture', 'postmortem', 'lessons learned'];
+
+function hasKeywords(text = '') {
+  const lower = text.toLowerCase();
+  return KEYWORDS.some(k => lower.includes(k));
+}
+
+async function pageWordCount(url) {
+  const ctrl = new AbortController();
+  const id = setTimeout(() => ctrl.abort(), 8000);
+  try {
+    const res = await fetch(url, { signal: ctrl.signal });
+    clearTimeout(id);
+    if (!res.ok) return 0;
+    const html = await res.text();
+    const plain = html.replace(/<script[\s\S]*?<\/script>/gi, '')
+      .replace(/<style[\s\S]*?<\/style>/gi, '')
+      .replace(/<[^>]+>/g, ' ');
+    return plain.split(/\s+/).filter(Boolean).length;
+  } catch {
+    clearTimeout(id);
+    return 0;
+  }
+}
+
 export async function search(question, env) {
   if (!env.TAVILY_API_KEY) {
     return { url: '<TO_FILL:TAVILY_API_KEY>', reason: 'no-key' };
   }
   const controller = new AbortController();
   const id = setTimeout(() => controller.abort(), 8000);
-  const include_domains = env.ALLOWED_SITES?.split(',').map(s => s.trim()).filter(Boolean) || [];
+  const include_domains = env.ALLOWED_SITES?.split(',').map(s => s.trim()).filter(Boolean) || DEFAULT_DOMAINS;
+  const query = `${question} ${KEYWORDS.join(' ')}`;
   const body = {
-    query: question,
+    query,
     include_domains,
     days: parseInt(env.DAYS_LIMIT || '1460', 10),
     lang_threshold: parseFloat(env.LANG_THRESHOLD || '0.9'),
@@ -30,11 +68,17 @@ export async function search(question, env) {
     }
     const data = await res.json();
     const results = data.results || [];
-    const english = results.find(r => r.language === 'en' && r.url);
-    const url = english?.url || results[0]?.url;
-    const hasUrl = !!url;
-    console.log('tavily.res', { status: res.status, hasUrl });
-    if (hasUrl) return { url, reason: 'ok' };
+    for (const r of results) {
+      if (r.language !== 'en' || !r.url) continue;
+      const text = `${r.title || ''} ${r.content || ''} ${r.snippet || ''}`;
+      if (!hasKeywords(text)) continue;
+      const count = await pageWordCount(r.url);
+      if (count >= 1000 && count <= 3000) {
+        console.log('tavily.res', { status: res.status, hasUrl: true });
+        return { url: r.url, reason: 'ok' };
+      }
+    }
+    console.log('tavily.res', { status: res.status, hasUrl: false });
     return { url: '<검색 결과 없음>', reason: 'no-results' };
   } catch (e) {
     console.log('tavily.res', { status: 'error', hasUrl: false });


### PR DESCRIPTION
## Summary
- restrict Tavily search to known engineering blog domains
- filter results by deep-dive keywords and 1k-3k word count
- document default `ALLOWED_SITES` behavior

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c3b8c31d5c832ba94d5334b1730843