### PR TITLE
Filter Tavily to deep corporate engineering posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,25 @@ TAVILY_API_KEY
 ALLOWED_SITES
 DAYS_LIMIT=1460
 LANG_THRESHOLD=0.9
+MIN_WORDS=1000
+MAX_WORDS=4000
 ```
+
+`ALLOWED_SITES` is prepopulated with domains from a wide range of English
+corporate engineering blogs (Spotify, Netflix, Uber, Airbnb, Shopify, Slack,
+Cloudflare, Google, AWS, Microsoft, Spring, GitHub, LinkedIn, Meta, Confluent,
+HashiCorp, Databricks, Grafana, Datadog, Elastic, Kubernetes, Istio, NGINX,
+Redis, Dropbox, Stripe and Apple). Modify the comma-separated list in
+`wrangler.toml` to customize the sources that Tavily will search. The worker
+splits the allowlist into batches of ten domains per Tavily request to avoid
+API limits. Queries are
+expanded with intent keywords ("deep dive", "case study", "architecture",
+"postmortem", "lessons learned", "guide", "explanation", "best practices") and
+exclude release-style terms. Results are scored by URL path, language and
+domain. Candidate pages are fetched and discarded unless they contain 1,000–4,000
+words, several section headings, code snippets and at least one of the intent
+keywords. If no suitable article is found, the worker retries with advanced
+search depth and finally with a small set of fallback sources.
 
 ## Deployment
 

--- a/src/tavily.js
+++ b/src/tavily.js
@@ -1,43 +1,169 @@
-export async function search(question, env) {
-  if (!env.TAVILY_API_KEY) {
-    return { url: '<TO_FILL:TAVILY_API_KEY>', reason: 'no-key' };
-  }
+const GOOD_PATH_RE = /(blog|engineering|techblog|\/blogs\/|\/insights\/|\/guides\/)/i;
+const BAD_PATH_RE = /(docs|reference|api|sdk|release-notes|\/ko-)/i;
+const BAD_TITLE_RE = /(announc(ing|ement)?|update|release notes?)/i;
+const KEYWORD_RE = /(deep dive|case study|architecture|postmortem|lessons learned)/i;
+
+function parseDomains(str) {
+  return str ? str.split(',').map(s => s.trim()).filter(Boolean) : [];
+}
+
+async function runSearch(body, key, timeoutMs = 12000) {
   const controller = new AbortController();
-  const id = setTimeout(() => controller.abort(), 8000);
-  const include_domains = env.ALLOWED_SITES?.split(',').map(s => s.trim()).filter(Boolean) || [];
-  const body = {
-    query: question,
-    include_domains,
-    days: parseInt(env.DAYS_LIMIT || '1460', 10),
-    lang_threshold: parseFloat(env.LANG_THRESHOLD || '0.9'),
-    max_results: 3
-  };
-  console.log('tavily.req', { question, include_domains: body.include_domains, days: body.days, lang_threshold: body.lang_threshold });
+  const id = setTimeout(() => controller.abort(), timeoutMs);
+  console.log('tavily.req', { question: body.query, include_domains: body.include_domains, depth: body.search_depth || 'basic' });
   try {
     const res = await fetch('https://api.tavily.com/search', {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${env.TAVILY_API_KEY}`
-      },
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${key}` },
       body: JSON.stringify(body),
       signal: controller.signal
     });
     clearTimeout(id);
     if (!res.ok) {
-      console.log('tavily.res', { status: res.status, hasUrl: false });
-      return { url: '<검색 실패>', reason: `http-${res.status}` };
+      console.log('tavily.res', { status: res.status, results: 0 });
+      return [];
     }
     const data = await res.json();
     const results = data.results || [];
-    const english = results.find(r => r.language === 'en' && r.url);
-    const url = english?.url || results[0]?.url;
-    const hasUrl = !!url;
-    console.log('tavily.res', { status: res.status, hasUrl });
-    if (hasUrl) return { url, reason: 'ok' };
-    return { url: '<검색 결과 없음>', reason: 'no-results' };
+    console.log('tavily.res', { status: res.status, results: results.length });
+    return results;
   } catch (e) {
-    console.log('tavily.res', { status: 'error', hasUrl: false });
-    return { url: '<검색 실패>', reason: e.name === 'AbortError' ? 'timeout' : 'error' };
+    console.log('tavily.res', { status: 'error', results: 0 });
+    return [];
   }
 }
+
+async function analyze(url) {
+  try {
+    const controller = new AbortController();
+    const id = setTimeout(() => controller.abort(), 5000);
+    const res = await fetch(url, { signal: controller.signal });
+    clearTimeout(id);
+    const html = await res.text();
+    const text = html.replace(/<[^>]+>/g, ' ');
+    const words = text.trim().split(/\s+/).length;
+    const headings = (html.match(/<h[23][^>]*>/gi) || []).length;
+    const hasCode = /<pre|<code|```/.test(html);
+    const hasKeyword = KEYWORD_RE.test(text.toLowerCase());
+    return { words, headings, hasCode, hasKeyword };
+  } catch {
+    return { words: 0, headings: 0, hasCode: false, hasKeyword: false };
+  }
+}
+
+export async function search(question, env) {
+  if (!env.TAVILY_API_KEY) {
+    return { url: '<TO_FILL:TAVILY_API_KEY>', reason: 'no-key' };
+  }
+  const coreDomains = parseDomains(env.ALLOWED_SITES) || [];
+  const defaultDomains = coreDomains.length
+    ? coreDomains
+    : [
+        'engineering.atspotify.com',
+        'netflixtechblog.com',
+        'eng.uber.com',
+        'airbnb.io',
+        'shopify.engineering',
+        'slack.engineering',
+        'blog.cloudflare.com',
+        'cloud.google.com',
+        'aws.amazon.com',
+        'learn.microsoft.com',
+        'docs.spring.io',
+        'github.blog',
+        'engineering.linkedin.com',
+        'engineering.fb.com',
+        'confluent.io',
+        'hashicorp.com',
+        'databricks.com',
+        'grafana.com',
+        'datadoghq.com',
+        'elastic.co',
+        'kubernetes.io',
+        'istio.io',
+        'nginx.com',
+        'redis.io',
+        'dropbox.tech',
+        'stripe.com',
+        'developer.apple.com',
+        'developers.googleblog.com'
+      ];
+  const fallbackDomains = ['martinfowler.com', 'infoq.com', 'highscalability.com'];
+  const days = parseInt(env.DAYS_LIMIT || '1460', 10);
+  const langThreshold = parseFloat(env.LANG_THRESHOLD || '0.9');
+  const minWords = parseInt(env.MIN_WORDS || '1000', 10);
+  const maxWords = parseInt(env.MAX_WORDS || '4000', 10);
+  const intent = '(deep dive OR case study OR architecture OR postmortem OR lessons learned OR guide OR explanation OR best practices)';
+  const exclude = '-reference -api -sdk -release notes -announcing -announcement -update';
+  const baseQuery = `${question} ${intent} ${exclude}`;
+
+  async function attempt(domains, depth) {
+    const chunks = [];
+    for (let i = 0; i < domains.length; i += 10) {
+      chunks.push(domains.slice(i, i + 10));
+    }
+    let results = [];
+    for (const chunk of chunks) {
+      const body = {
+        query: baseQuery,
+        include_domains: chunk,
+        days,
+        lang_threshold: langThreshold,
+        max_results: 5
+      };
+      if (depth) body.search_depth = depth;
+      results = results.concat(await runSearch(body, env.TAVILY_API_KEY));
+    }
+    const scored = results
+      .map(r => ({ ...r, score: score(r) }))
+      .filter(r => r.score > -Infinity)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 5);
+    const evaluated = await Promise.all(
+      scored.map(async r => ({ ...r, ...(await analyze(r.url)) }))
+    );
+    const good = evaluated.filter(
+      r =>
+        r.words >= minWords &&
+        r.words <= maxWords &&
+        r.headings >= 3 &&
+        r.hasCode &&
+        r.hasKeyword
+    );
+    good.sort((a, b) => b.score - a.score);
+    return good[0]?.url;
+  }
+
+  function score(r) {
+    try {
+      const u = new URL(r.url);
+      const path = u.pathname.toLowerCase();
+      const title = (r.title || '').toLowerCase();
+      if (BAD_PATH_RE.test(path) || BAD_TITLE_RE.test(title)) return -Infinity;
+      let s = 0;
+      if (GOOD_PATH_RE.test(path)) s += 4;
+      const text = `${r.title || ''} ${r.url}`;
+      const letters = (text.match(/[a-z]/gi) || []).length;
+      const total = (text.match(/[a-z0-9]/gi) || []).length;
+      if (total && letters / total > 0.8) s += 1;
+      if (defaultDomains.some(d => u.hostname.endsWith(d))) s += 2;
+      return s;
+    } catch {
+      return -Infinity;
+    }
+  }
+
+  let url = await attempt(defaultDomains);
+  let reason = url ? 'ok' : 'no-results';
+  if (!url) {
+    url = await attempt(defaultDomains, 'advanced');
+    if (url) reason = 'advanced';
+  }
+  if (!url) {
+    url = await attempt(defaultDomains.concat(fallbackDomains), 'advanced');
+    if (url) reason = 'fallback';
+  }
+  if (url) return { url, reason };
+  return { url: '<검색 결과 없음>', reason };
+}
+

--- a/src/worker.js
+++ b/src/worker.js
@@ -49,7 +49,22 @@ async function processCategory({ user_id, text, response_url, trigger_id }, env)
 }
 
 async function processSummary(data, env) {
-  const { userId, category, question, link, userConcept, userOral, userExpressions, userReflection, response_url } = data;
+  const {
+    userId,
+    category,
+    question,
+    link,
+    userConcept = '',
+    userOral = '',
+    userExpressions = '',
+    userReflection = '',
+    response_url
+  } = data;
+  if (!category || !question || !link) {
+    if (response_url) await sendResponseUrl(response_url, '오늘의 질문이 없습니다. `/카테고리`로 질문을 먼저 받아주세요.');
+    await logRequest(env.DB, { userId, path: '/slack/summary', method: 'POST', note: 'missing-data' });
+    return;
+  }
   try {
     const keywords = await extractKeywords(env, `${question}\n${userConcept}\n${userOral}\n${userExpressions}\n${userReflection}`);
     const date = kstDate();

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -12,6 +12,8 @@ database_name = "dtlogs-db"
 database_id = "0614bd30-1c0b-40a2-98de-34efa2b54247"
 
 [vars]
-ALLOWED_SITES = ""
+ALLOWED_SITES = "engineering.atspotify.com,netflixtechblog.com,eng.uber.com,airbnb.io,shopify.engineering,slack.engineering,blog.cloudflare.com,cloud.google.com,aws.amazon.com,learn.microsoft.com,docs.spring.io,github.blog,engineering.linkedin.com,engineering.fb.com,confluent.io,hashicorp.com,databricks.com,grafana.com,datadoghq.com,elastic.co,kubernetes.io,istio.io,nginx.com,redis.io,dropbox.tech,stripe.com,developer.apple.com,developers.googleblog.com"
 DAYS_LIMIT = "1460"
 LANG_THRESHOLD = "0.9"
+MIN_WORDS = "1000"
+MAX_WORDS = "4000"


### PR DESCRIPTION
## Summary
- Fetch and analyze candidate URLs, returning only allowlisted corporate posts with 1k–4k words, multiple sections, code snippets, and deep-dive keywords
- Exclude announcement-style results and expand query intent to target case studies and postmortems
- Split allowlists into batches of ten domains per Tavily request and raise request timeout to avoid search errors

## Testing
- `node --no-warnings -e "import('./src/tavily.js').then(()=>console.log('tavily imported')).catch(err=>console.error('import error',err))"`
- `node --no-warnings -e "import('./src/worker.js').then(()=>console.log('worker imported')).catch(err=>console.error('import error',err))"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e7b27ba0832ba2d62731ba14169e